### PR TITLE
Allow stats authentication to be enabled or disabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,7 @@ haproxy_default_errorfiles:
 haproxy_stats: true
 haproxy_stats_address: '*'
 haproxy_stats_port: 9001
+haproxy_stats_auth: true
 haproxy_stats_user: haproxy-stats
 haproxy_stats_password: B1Gp4sSw0rD!!
 haproxy_stats_uri: /

--- a/templates/etc/haproxy/haproxy-stats.cfg.j2
+++ b/templates/etc/haproxy/haproxy-stats.cfg.j2
@@ -11,9 +11,11 @@ listen stats
     stats      show-legends
     stats      show-node
     stats      hide-version
-    stats      realm Haproxy\ Statistics
     stats      uri {{ haproxy_stats_uri }}
+    {% if haproxy_stats_auth %}
+    stats      realm Haproxy\ Statistics
     stats      auth {{ haproxy_stats_user }}:{{ haproxy_stats_password }}
+    {% endif %}
     timeout    client 100s
     timeout    server 100s
     timeout    connect 100s


### PR DESCRIPTION
A simple toggle to allow users to choose whether to put authentication on the stats endpoint.
