### PR TITLE
Added support for rate-limit sessions cfg option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,8 @@ script:
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
+  # Test template expansion
+  - ansible-playbook tests/test-templates.yml -i tests/inventory
+
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/templates/etc/haproxy/haproxy-frontend.cfg.j2
+++ b/templates/etc/haproxy/haproxy-frontend.cfg.j2
@@ -64,6 +64,9 @@ frontend {{ name }}
     reqadd          {{ reqadd }}
                 {% endfor %}
             {% endif %}
+            {% if value.rate_limit_sessions is defined %}
+    rate-limit      sessions {{ value.rate_limit_sessions }}
+            {% endif %}
             {% if value.use_backends is defined %}
                 {% for use_backend in value.use_backends %}
     use_backend     {{ use_backend }}

--- a/templates/etc/haproxy/haproxy-listen.cfg.j2
+++ b/templates/etc/haproxy/haproxy-listen.cfg.j2
@@ -78,6 +78,9 @@ listen {{ name }}
     tcp-check       {{ tcp_check }}
                 {% endfor %}
             {% endif %}
+            {% if value.rate_limit_sessions is defined %}
+    rate-limit      sessions {{ value.rate_limit_sessions }}
+            {% endif %}
             {% if value.redirects is defined %}
                 {% for redirect in value.redirects %}
     redirect        {{ redirect }}

--- a/tests/test-templates.yml
+++ b/tests/test-templates.yml
@@ -1,0 +1,39 @@
+---
+- name: test empty component template expansion
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - vars/empty-components.yml
+  vars:
+    frontend: "{{ lookup('template', '../templates/etc/haproxy/haproxy-frontend.cfg.j2') }}"
+    listener: "{{ lookup('template', '../templates/etc/haproxy/haproxy-listen.cfg.j2') }}"
+  tasks:
+    - name: verify no rate-limit in definition
+      assert:
+        that:
+          - item is not search('rate-limit +sessions')
+      with_items:
+        - frontend
+        - listener
+
+
+- name: test rate-limit sessions template expansion
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - vars/rate-limited.yml
+  vars:
+    frontend: "{{ lookup('template', '../templates/etc/haproxy/haproxy-frontend.cfg.j2') }}"
+    listener: "{{ lookup('template', '../templates/etc/haproxy/haproxy-listen.cfg.j2') }}"
+  tasks:
+    - name: verify rate-limit in frontend definition
+      assert:
+        that:
+          - frontend is search('\n +rate-limit +sessions +1\n')
+
+    - name: verify rate-limit in listen definition
+      assert:
+        that:
+          - listener is search('\n +rate-limit +sessions +2\n')

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,4 +1,7 @@
 ---
+- import_playbook: test-templates.yml
+
+
 - hosts: localhost
   remote_user: root
   roles:
@@ -20,9 +23,10 @@
             - url_static path_end -i .jpg .gif .png .css .js
           bind_process:
             - 1
+          rate_limit_sessions: 10
           use_backends:
             - static if url_static
-    
+
     # Backend
     haproxy_backend:
       - dashboard_backend:
@@ -41,7 +45,7 @@
             - ctrl01 10.0.0.67:8080 check
             - ctrl02 10.0.0.68:8080 check
             - ctrl03 10.0.0.69:8080 check
-    
+
     # Listen
     haproxy_listen:
       - dashboard_cluster:
@@ -57,11 +61,12 @@
             - 1
           http_requests:
             - set-header X-Haproxy-Current-Date %T
+          rate_limit_sessions: 20
           servers:
             - ctrl01 10.0.0.67:80 check inter 2000 rise 2 fall 5
             - ctrl02 10.0.0.68:80 check inter 2000 rise 2 fall 5
             - ctrl03 10.0.0.69:80 check inter 2000 rise 2 fall 5
-    
+
       - neutron_api_cluster:
           binds_ssl:
             - 10.0.0.100:9696 {{ haproxy_ssl }}
@@ -72,7 +77,7 @@
             - ctrl01 10.0.0.62:9696 check inter 2000 rise 2 fall 5
             - ctrl02 10.0.0.63:9696 check inter 2000 rise 2 fall 5
             - ctrl03 10.0.0.64:9696 check inter 2000 rise 2 fall 5
-    
+
     # Peer
     haproxy_peer:
       - remote_peers:

--- a/tests/vars/empty-components.yml
+++ b/tests/vars/empty-components.yml
@@ -1,0 +1,7 @@
+---
+haproxy_frontend:
+  - test_frontend: {}
+
+haproxy_listen:
+  - test_listener:
+      servers: []

--- a/tests/vars/rate-limited.yml
+++ b/tests/vars/rate-limited.yml
@@ -1,0 +1,9 @@
+---
+haproxy_frontend:
+  - test_frontend: 
+      rate_limit_sessions: 1
+
+haproxy_listen:
+  - test_listener:
+      rate_limit_sessions: 2
+      servers: []


### PR DESCRIPTION
The frontend and listen templates were extended to support the
`rate-limit sessions <rate>` HAProxy configuration option. If the key
`rate_limit_sessions` is added to an entry in the
`haproxy_frontend`  or `haproxy_listen` array with a value of `<rate>`, the
corresponding frontend or listener will limited to receiving at most <rate> 
new sessions per second.

I'm sorry about the white space removal in `tests/test.yml`. I didn't catch 
that Atom, my text editor, had automatically removed the white space until
just now.