### PR TITLE
Add Ansible Molecule configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-pip
+      - python-pip
 
 install:
   # Install ansible

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,14 @@
 ---
 language: python
-python: "2.7"
-
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-      - python-pip
-
+python:
+  - "2.7"
+  - "3.6"
+sudo: required
+services:
+  - docker
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
-
+  - pip install docker molecule
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
-
-  # Test template expansion
-  - ansible-playbook tests/test-templates.yml -i tests/inventory
-
+  - molecule test
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This role provides support for the installation of HAproxy on current distributi
 
  - CentOS **7.x**
  - RedHat **7.x**
- - Ubuntu **14.xx** / **15.xx** / **16.xx**
+ - Fedora **29**
+ - Ubuntu **14.xx** / **15.xx** / **16.xx** / **18.04**
  - Debian **7.x** / **8.x** / **9.x**
 
 The role allows you to configure multiple sections of HAproxy:
@@ -221,6 +222,20 @@ haproxy_peer:
         - lb223 10.0.0.223:1024
         - lb224 10.0.0.224:1024
         - lb225 10.0.0.225:1024
+```
+
+Testing
+-------
+
+This role is using [ansible molecule](https://molecule.readthedocs.io/).
+You'll just need to install molecule via pip and run it.
+Currently the molecule configuration is based on the docker driver.
+
+```console
+$ apt/yum install docker
+$ systemctl start docker
+$ pip install docker molecule
+$ molecule test
 ```
 
 License

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,10 +2,10 @@
 # file: roles/haproxy/handlers/main.yml
 - name: restart haproxy
   service:
-    name=haproxy
-    state=restarted
+    name: haproxy
+    state: restarted
 
 - name: reload haproxy
   service:
-    name=haproxy
-    state=reloaded
+    name: haproxy
+    state: reloaded

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,40 +1,35 @@
+---
 galaxy_info:
   author: Gaëtan Trellu - goldyfruit
   description: Install and configure HAproxy
   company: InCloudUs
-  
   issue_tracker_url: https://github.com/uoi-io/ansible-haproxy/issues
-  
   license: Apache
-  
   min_ansible_version: 2.0
-
   github_branch: master
-  
   platforms:
-  - name: EL
-    versions:
-    - 7
-  - name: Fedora
-    versions:
-    - 22
-    - 23
-    - 24
-    - 25
-  - name: Ubuntu
-    versions:
-    - trusty
-    - utopic
-    - vivid
-    - wily
-    - xenial
-    - yakkety
-  - name: Debian
-    versions:
-    - jessie
-    - wheezy
-    - stretch
-
+    - name: EL
+      versions:
+        - 7
+    - name: Fedora
+      versions:
+        - 22
+        - 23
+        - 24
+        - 25
+    - name: Ubuntu
+      versions:
+        - trusty
+        - utopic
+        - vivid
+        - wily
+        - xenial
+        - yakkety
+    - name: Debian
+      versions:
+        - jessie
+        - wheezy
+        - stretch
   galaxy_tags:
     - cloud
     - system

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
         - 23
         - 24
         - 25
+        - 29
     - name: Ubuntu
       versions:
         - trusty
@@ -25,6 +26,7 @@ galaxy_info:
         - wily
         - xenial
         - yakkety
+        - bionic
     - name: Debian
       versions:
         - jessie

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,9 @@
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install --no-install-recommends -y net-tools procps python && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf install -y net-tools procps-ng && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum install -y net-tools procps-ng && yum clean all; fi

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,56 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: debian9
+    image: debian:9
+    command: sleep infinity
+    groups: [ Debian ]
+    privileged: true
+  - name: el7
+    image: centos:7
+    command: /sbin/init
+    groups: [ RedHat ]
+    privileged: true
+  - name: f29
+    image: fedora:29
+    command: /sbin/init
+    groups: [ RedHat ]
+    privileged: true
+  - name: ubuntu18.04
+    image: ubuntu:18.04
+    command: sleep infinity
+    groups: [ Debian ]
+    privileged: true
+provisioner:
+  name: ansible
+  inventory:
+    group_vars:
+      Debian:
+        apache_pkg: apache2
+        apache_service: apache2
+        apache_ports: /etc/apache2/ports.conf
+        apache_conf_d: /etc/apache2/conf-enabled
+      RedHat:
+        apache_pkg: httpd
+        apache_service: httpd
+        apache_ports: /etc/httpd/conf/httpd.conf
+        apache_conf_d: /etc/httpd/conf.d
+    host_vars:
+      f29:
+        ansible_python_interpreter: python3
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  options:
+    v: true
+  lint:
+    name: flake8

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,0 +1,36 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - import_role:
+        name: ansible-haproxy
+      vars:
+        haproxy_firewalld: false
+        haproxy_selinux: false
+        haproxy_default_mode: http
+        haproxy_listen:
+          - dashboard_cluster:
+              mode: http
+              description: Horizon Dashboard
+              balance: roundrobin
+              binds:
+                - '*:80'
+              options: [ tcpka, httpchk, tcplog ]
+              http_requests:
+                - set-header X-Haproxy-Current-Date %T
+              rate_limit_sessions: 20
+              servers:
+                - ctrl01 127.0.0.1:8080 check inter 2000 rise 2 fall 5
+                - ctrl02 127.0.0.1:8081 check inter 2000 rise 2 fall 5
+                - ctrl03 127.0.0.1:8082 check inter 2000 rise 2 fall 5
+          - neutron_api_cluster:
+              mode: http
+              description: Neutron API
+              balance: source
+              binds:
+                - '*:9696'
+              options: [ tcpka, httpchk, tcplog ]
+              servers:
+                - ctrl01 127.0.0.1:19696 check inter 2000 rise 2 fall 5
+                - ctrl02 127.0.0.1:19697 check inter 2000 rise 2 fall 5
+                - ctrl03 127.0.0.1:19698 check inter 2000 rise 2 fall 5

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,36 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Install apache package
+      package:
+        name: '{{ apache_pkg }}'
+
+    - name: Remove default listen 80
+      lineinfile:
+        dest: '{{ apache_ports }}'
+        regexp: '^Listen 80$'
+        state: absent
+
+    - name: Add custom listen ports
+      copy:
+        dest: '{{ apache_conf_d }}/backends.conf'
+        content: |
+          Listen 8080
+          Listen 8081
+          Listen 8082
+          Listen 19696
+          Listen 19697
+          Listen 19698
+
+    - name: Add default index.html
+      copy:
+        src: /usr/share/httpd/noindex/index.html
+        dest: /var/www/html/index.html
+        remote_src: true
+      when: ansible_os_family == 'RedHat'
+
+    - name: Start apache service
+      service:
+        name: '{{ apache_service }}'
+        state: started

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,0 +1,87 @@
+import os
+import pytest
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_package_installed(host):
+    p = host.package('haproxy')
+    assert p.is_installed
+
+
+def test_service_running_and_enabled(host):
+    s = host.service('haproxy')
+    assert s.is_enabled
+    assert s.is_running
+
+
+def test_main_config(host):
+    f = host.file('/etc/haproxy/haproxy.cfg')
+    assert f.exists
+    assert f.is_file
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o644
+    assert f.contains('mode       http')
+    assert f.contains('stats      enable')
+    assert f.contains('listen dashboard_cluster')
+    assert f.contains('listen neutron_api_cluster')
+
+
+@pytest.mark.parametrize('protocol,port', [
+    ('tcp', '80'),
+    ('tcp', '9001'),
+    ('tcp', '9696'),
+])
+def test_listening_socket(host, protocol, port):
+    s = host.socket('%s://0.0.0.0:%s' % (protocol, port))
+    assert s.is_listening
+
+
+@pytest.mark.parametrize('filename,key,value', [
+    ('10-ip_nonlocal_bind.conf', 'net.ipv4.ip_nonlocal_bind', '1'),
+    ('10-ip_forward.conf', 'net.ipv4.ip_forward', '1')
+])
+def test_sysctl_config(host, filename, key, value):
+    f = host.file('/etc/sysctl.d/%s' % filename)
+    assert f.exists
+    assert f.is_file
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o644
+    assert f.contains('%s=%s' % (key, value))
+
+
+@pytest.mark.parametrize('key,value', [
+    ('net.ipv4.ip_nonlocal_bind', 1),
+    ('net.ipv4.ip_forward', 1)
+])
+def test_sysctl_value(host, key, value):
+    assert host.sysctl(key) == value
+
+
+@pytest.mark.parametrize('user,password,status', [
+    ('haproxy-stats', 'B1Gp4sSw0rD!!', 200),
+    ('foo', 'bar', 401)
+])
+def test_haproxy_stats(host, user, password, status):
+    assert host.ansible(
+       'uri',
+       'url=http://127.0.0.1:9001 \
+        user=%s \
+        password=%s' % (user, password),
+       check=False)['status'] == status
+
+
+@pytest.mark.parametrize('port', [
+    ('80'),
+    ('9696')
+])
+def test_haproxy_listen(host, port):
+    assert host.ansible(
+       'uri',
+       'url=http://127.0.0.1:%s' % port,
+       check=False)['status'] == 200

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,7 +2,7 @@
 # file: roles/haproxy/tasks/config.yml
 - name: Configuring HAproxy
   template:
-    src=etc/haproxy/haproxy.cfg.j2
-    dest=/etc/haproxy/haproxy.cfg
-    validate='haproxy -f %s -c'
+    src: etc/haproxy/haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
+    validate: 'haproxy -f %s -c'
   notify: reload haproxy

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -2,8 +2,8 @@
 # file: roles/haproxy/tasks/firewall.yml
 - name: HAproxy firewalld rule
   firewalld:
-    port={{ item }}
-    permanent=true
-    state=enabled
-    immediate=true
+    port: '{{ item }}'
+    permanent: true
+    state: enabled
+    immediate: true
   with_items: "{{ haproxy_fw_ports }}"

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,6 +1,7 @@
 ---
 # file: roles/haproxy/tasks/install-Debian.yml
-- set_fact:
+- name: Set haproxy release
+  set_fact:
     haproxy_release: "{{ ansible_distribution_release }}-backports"
   when: haproxy_apt_backports | bool
 

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -8,6 +8,6 @@
   apt:
     name: haproxy
     state: present
-    update_cache: True
+    update_cache: true
     cache_valid_time: 3600
     default_release: "{{ haproxy_release | default(ansible_distribution_release) }}"

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -2,8 +2,7 @@
 # file: roles/haproxy/tasks/install-Debian.yml
 - set_fact:
     haproxy_release: "{{ ansible_distribution_release }}-backports"
-  when: haproxy_apt_backports is defined and
-        haproxy_apt_backports
+  when: haproxy_apt_backports | bool
 
 - name: "Installing HAproxy from {{ haproxy_release | default(ansible_distribution_release) }}"
   apt:

--- a/tasks/install-Generic.yml
+++ b/tasks/install-Generic.yml
@@ -3,4 +3,3 @@
 - name: Installing HAproxy package
   package:
     name: haproxy
-    state: latest

--- a/tasks/install-Generic.yml
+++ b/tasks/install-Generic.yml
@@ -2,5 +2,5 @@
 # file: roles/haproxy/tasks/install-Generic.yml
 - name: Installing HAproxy package
   package:
-    name=haproxy
-    state=latest
+    name: haproxy
+    state: latest

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,6 +7,6 @@
 
 - name: Enabling and starting HAproxy service
   service:
-    name=haproxy
-    state=started
-    enabled=yes
+    name: haproxy
+    state: started
+    enabled: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,4 +9,4 @@
   service:
     name: haproxy
     state: started
-    enabled: yes
+    enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # file: roles/haproxy/tasks/main.yml
-- include_vars: "{{ ansible_os_family }}.yml"
+- name: Include OS variables
+  include_vars: "{{ ansible_os_family }}.yml"
   tags:
     - haproxy
     - haproxy-install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,8 +14,7 @@
 
 - include: firewall.yml
   tags: [ haproxy, haproxy-firewall ]
-  when: haproxy_firewalld is defined and
-        haproxy_firewalld | bool
+  when: haproxy_firewalld | bool
 
 - include: selinux.yml
   tags: [ haproxy, haproxy-selinux ]

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -10,5 +10,5 @@
 - name: Enabling SELinux booleans for HAproxy
   seboolean:
     name: haproxy_connect_any
-    state: yes
-    persistent: yes
+    state: true
+    persistent: true

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -2,13 +2,13 @@
 # file: roles/haproxy/tasks/selinux.yml
 - name: Allowing HAproxy to listen on some TCP ports
   seport:
-    ports="{{ haproxy_stats_port }}"
-    proto=tcp
-    setype=tor_port_t
-    state=present
+    ports: "{{ haproxy_stats_port }}"
+    proto: tcp
+    setype: tor_port_t
+    state: present
 
 - name: Enabling SELinux booleans for HAproxy
   seboolean:
-    name=haproxy_connect_any
-    state=yes
-    persistent=yes
+    name: haproxy_connect_any
+    state: yes
+    persistent: yes

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -5,8 +5,8 @@
     name: net.ipv4.ip_nonlocal_bind
     value: 1
     sysctl_file: /etc/sysctl.d/10-ip_nonlocal_bind.conf
-    sysctl_set: yes
-    reload: yes
+    sysctl_set: true
+    reload: true
     state: present
   notify: restart haproxy
   when: haproxy_bind_nonlocal_ip | bool
@@ -16,7 +16,7 @@
     name: net.ipv4.ip_forward
     value: 1
     sysctl_file: /etc/sysctl.d/10-ip_forward.conf
-    sysctl_set: yes
-    reload: yes
+    sysctl_set: true
+    reload: true
     state: present
   when: haproxy_ip_forward | bool

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -2,23 +2,21 @@
 # file: roles/haproxy/tasks/sysctl.yml
 - name: Enabling/Disabling net.ipv4.ip_nonlocal_bind option
   sysctl:
-    name=net.ipv4.ip_nonlocal_bind
-    value=1
-    sysctl_file=/etc/sysctl.d/10-ip_nonlocal_bind.conf
-    sysctl_set=yes
-    reload=yes
-    state=present
+    name: net.ipv4.ip_nonlocal_bind
+    value: 1
+    sysctl_file: /etc/sysctl.d/10-ip_nonlocal_bind.conf
+    sysctl_set: yes
+    reload: yes
+    state: present
   notify: restart haproxy
-  when: haproxy_bind_nonlocal_ip is defined and
-        haproxy_bind_nonlocal_ip | bool
+  when: haproxy_bind_nonlocal_ip | bool
 
 - name: Enabling/Disabling net.ipv4.ip_forward option
   sysctl:
-    name=net.ipv4.ip_forward
-    value=1
-    sysctl_file=/etc/sysctl.d/10-ip_forward.conf
-    sysctl_set=yes
-    reload=yes
-    state=present
-  when: haproxy_ip_forward is defined and
-        haproxy_ip_forward | bool
+    name: net.ipv4.ip_forward
+    value: 1
+    sysctl_file: /etc/sysctl.d/10-ip_forward.conf
+    sysctl_set: yes
+    reload: yes
+    state: present
+  when: haproxy_ip_forward | bool


### PR DESCRIPTION
This will replace the current ansible syntax check by the ansible molecule framework.

This includes:
  - lint (yamllint, ansible-lint and flake8).
  - role execution and idempotency.
  - unit tests via testinfra.

The current configuration tests the role on:
  - centos 7
  - debian 9 (stretch)
  - fedora 29
  - ubuntun 18.04 (bionic)