### PR TITLE
sysctl: use string for value instead of int

### DIFF
--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -3,7 +3,7 @@
 - name: Enabling/Disabling net.ipv4.ip_nonlocal_bind option
   sysctl:
     name: net.ipv4.ip_nonlocal_bind
-    value: 1
+    value: '1'
     sysctl_file: /etc/sysctl.d/10-ip_nonlocal_bind.conf
     sysctl_set: true
     reload: true
@@ -14,7 +14,7 @@
 - name: Enabling/Disabling net.ipv4.ip_forward option
   sysctl:
     name: net.ipv4.ip_forward
-    value: 1
+    value: '1'
     sysctl_file: /etc/sysctl.d/10-ip_forward.conf
     sysctl_set: true
     reload: true


### PR DESCRIPTION
```console
[WARNING]: The value 1 (type int) in a string field was converted to '1' (type
string). If this does not look like what you expect, quote the entire value to
ensure it does not change.
```