### PR TITLE
IMP support customization of package, service, config and binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ haproxy_firewalld: true
 haproxy_selinux: true
 haproxy_apt_backports: false
 
+# Package customizations
+haproxy_package: haproxy
+haproxy_service: haproxy
+haproxy_bin: haproxy
+haproxy_config: /etc/haproxy/haproxy.cfg
+
 # Firewall
 haproxy_fw_ports:
   - "{{ haproxy_stats_port }}/tcp"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,12 @@ haproxy_firewalld: true
 haproxy_selinux: true
 haproxy_apt_backports: false
 
+# Package customizations
+haproxy_package: haproxy
+haproxy_service: haproxy
+haproxy_bin: haproxy
+haproxy_config: /etc/haproxy/haproxy.cfg
+
 # Firewall
 haproxy_fw_ports:
   - "{{ haproxy_stats_port }}/tcp"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,10 +2,10 @@
 # file: roles/haproxy/handlers/main.yml
 - name: restart haproxy
   service:
-    name: haproxy
+    name: "{{ haproxy_service }}"
     state: restarted
 
 - name: reload haproxy
   service:
-    name: haproxy
+    name: "{{ haproxy_service }}"
     state: reloaded

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -3,6 +3,6 @@
 - name: Configuring HAproxy
   template:
     src: etc/haproxy/haproxy.cfg.j2
-    dest: /etc/haproxy/haproxy.cfg
-    validate: 'haproxy -f %s -c'
+    dest: "{{ haproxy_config }}"
+    validate: "{{ haproxy_bin }} -f %s -c"
   notify: reload haproxy

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -7,7 +7,7 @@
 
 - name: "Installing HAproxy from {{ haproxy_release | default(ansible_distribution_release) }}"
   apt:
-    name: haproxy
+    name: "{{ haproxy_package }}"
     state: present
     update_cache: true
     cache_valid_time: 3600

--- a/tasks/install-Generic.yml
+++ b/tasks/install-Generic.yml
@@ -2,4 +2,4 @@
 # file: roles/haproxy/tasks/install-Generic.yml
 - name: Installing HAproxy package
   package:
-    name: haproxy
+    name: "{{ haproxy_package }}"


### PR DESCRIPTION
Currently one of way to install HaProxy LTS version on CentOS is to install via Software Collections.
But there's issues with package, service names and config and binary path.

This commit adds support for customizing:
- Package name. For Software Collections: rh-haproxy18
- Service name. In case of Software Collections: rh-haproxy18-haproxy
- Config file location. For Software Collections: /etc/opt/rh/rh-haproxy18/haproxy/haproxy.cfg
- Binnary path. Example: /opt/rh/rh-haproxy18/root/usr/sbin/haproxy