### PR TITLE
molecule: update configuration to 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 services:
   - docker
 install:
-  - pip install ansible==${ANSIBLE_VERSION}.* docker molecule
+  - pip install ansible==${ANSIBLE_VERSION}.* docker molecule ansible-lint yamllint flake8 testinfra
 script:
   - molecule test
 notifications:

--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,4 @@
+---
 extends: default
 
 rules:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,8 +4,11 @@ dependency:
   enabled: false
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint --exclude=molecule/ --exclude=tests/
+  flake8
 platforms:
   - name: debian9
     image: debian:9
@@ -44,13 +47,9 @@ provisioner:
     host_vars:
       f29:
         ansible_python_interpreter: python3
-  lint:
-    name: ansible-lint
 scenario:
   name: default
 verifier:
   name: testinfra
   options:
     v: true
-  lint:
-    name: flake8

--- a/tests/vars/rate-limited.yml
+++ b/tests/vars/rate-limited.yml
@@ -1,6 +1,6 @@
 ---
 haproxy_frontend:
-  - test_frontend: 
+  - test_frontend:
       rate_limit_sessions: 1
 
 haproxy_listen:


### PR DESCRIPTION
Since 3.x, molecule uses external lint commands rather explicit lint
sections in lint/provisioner/verifier.
So will need to explicitly install those lint tools via pip.
This is the same for the verifier command (testinfra).

https://molecule.readthedocs.io/en/latest/configuration.html#lint

Signed-off-by: Dimitri Savineau <savineau.dimitri@gmail.com>