### PR TITLE
remove empty var haproxy_default_mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,7 @@ haproxy_global_tunes:
 # Default
 haproxy_default_logs:
   - global
+haproxy_default_mode:
 haproxy_default_maxconn: 4000
 haproxy_default_fullconn:
 haproxy_default_options:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,6 @@ haproxy_global_tunes:
 # Default
 haproxy_default_logs:
   - global
-haproxy_default_mode:
 haproxy_default_maxconn: 4000
 haproxy_default_fullconn:
 haproxy_default_options:

--- a/templates/etc/haproxy/haproxy-default.cfg.j2
+++ b/templates/etc/haproxy/haproxy-default.cfg.j2
@@ -36,6 +36,6 @@ defaults
     errorfile   {{ errorfile }}
     {% endfor %}
 {% endif %}
-{% if haproxy_default_mode is defined %}
+{% if haproxy_default_mode is defined and haproxy_default_mode | length > 0 %}
     mode        {{ haproxy_default_mode }}
 {% endif %}


### PR DESCRIPTION
Fixes #30 

removing the variable so it doesn't need get written into the config file. 