### PR TITLE
Fixes #33: reqrep fix for frontend/backend templates

### DIFF
--- a/templates/etc/haproxy/haproxy-backend.cfg.j2
+++ b/templates/etc/haproxy/haproxy-backend.cfg.j2
@@ -48,6 +48,16 @@ backend {{ name }}
     http-response    {{ http_response }}
                 {% endfor %}
             {% endif %}
+            {% if value.reqrep is defined %}
+                {% for reqrep in value.reqrep %}
+    reqrep          {{ reqrep }}
+                {% endfor %}
+            {% endif %}
+            {% if value.reqirep is defined %}
+                {% for reqirep in value.reqirep %}
+    reqirep         {{ reqirep }}
+                {% endfor %}
+            {% endif %}
             {% if value.tcp_responses is defined %}
                 {% for tcp_response in value.tcp_responses %}
     tcp-response    {{ tcp_response }}

--- a/templates/etc/haproxy/haproxy-frontend.cfg.j2
+++ b/templates/etc/haproxy/haproxy-frontend.cfg.j2
@@ -67,6 +67,16 @@ frontend {{ name }}
     reqadd          {{ reqadd }}
                 {% endfor %}
             {% endif %}
+            {% if value.reqrep is defined %}
+                {% for reqrep in value.reqrep %}
+    reqrep          {{ reqrep }}
+                {% endfor %}
+            {% endif %}
+            {% if value.reqirep is defined %}
+                {% for reqirep in value.reqirep %}
+    reqirep         {{ reqirep }}
+                {% endfor %}
+            {% endif %}
             {% if value.rate_limit_sessions is defined %}
     rate-limit      sessions {{ value.rate_limit_sessions }}
             {% endif %}


### PR DESCRIPTION
This is a fix to the issue raised. I've not changed the haproxy-listen template due to the original implementation possibly being used elsewhere, but with some type checking it's easy to sort out a backward compatible fix for that template too...