### PR TITLE
Adding userlist groups to the main configuration

### DIFF
--- a/templates/etc/haproxy/haproxy-userlist.cfg.j2
+++ b/templates/etc/haproxy/haproxy-userlist.cfg.j2
@@ -1,0 +1,17 @@
+{% if haproxy_userlist %}
+##########################
+#       USERLIST         #
+##########################
+    {% for dict_item in haproxy_userlist %}
+        {% for name, value in dict_item.items() %}
+userlist {{ name }}
+            {% for group in value.groups %}
+    group       {{ group }}
+            {% endfor %}
+            {% for user in value.users %}
+    user        {{ user }}
+            {% endfor %} 
+        {% endfor %}
+
+    {% endfor %}
+{% endif %}

--- a/templates/etc/haproxy/haproxy.cfg.j2
+++ b/templates/etc/haproxy/haproxy.cfg.j2
@@ -7,6 +7,8 @@
 {# DEFAULT CONFIGURATION #}
 {% include 'haproxy-default.cfg.j2' %}
 
+{# USERLIST CONFIGURATION #}
+{% include 'haproxy-userlist.cfg.j2' %}
 {# STATS CONFIGURATION #}
 {% include 'haproxy-stats.cfg.j2' %}
 


### PR DESCRIPTION
Providing basic access for creation of haproxy userlists. [It's available in v1.5 as well](https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#userlist). 