### PR TITLE
Disabled deprecated haproxy_global_nbproc and haproxy_global_cpu_maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ haproxy_global_ulimit_n:
 haproxy_global_logs:
   - 127.0.0.1    local0 debug
 haproxy_global_daemon: true
-haproxy_global_nbproc: 8
-haproxy_global_cpu_maps: [ 1 0, 2 1, 3 2, 4 3, 5 4, 6 5, 7 6, 8 7 ]
+# nbproc is deprecated. Will be removed in version 2.5
+# haproxy_global_nbproc: 8
+# haproxy_global_cpu_maps: [ 1 0, 2 1, 3 2, 4 3, 5 4, 6 5, 7 6, 8 7 ]
 haproxy_global_tunes:
   - tune.ssl.default-dh-param: 2048
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,10 +38,10 @@ haproxy_global_description:
 haproxy_global_ulimit_n:
 haproxy_global_logs:
   - 127.0.0.1    local0 debug
-haproxy_global_nbproc: 2
-haproxy_global_cpu_maps:
-  - 1 0
-  - 2 1
+# haproxy_global_nbproc: 2
+# haproxy_global_cpu_maps:
+#   - 1 0
+#   - 2 1
 haproxy_global_tunes:
   - tune.ssl.default-dh-param: 2048
 

--- a/templates/etc/haproxy/haproxy-global.cfg.j2
+++ b/templates/etc/haproxy/haproxy-global.cfg.j2
@@ -5,7 +5,7 @@ global
     chroot     {{ haproxy_global_chroot | default('/var/lib/haproxy') }}
 {% if haproxy_global_daemon %}
     daemon
-    {% if haproxy_global_nbproc %}
+    {% if haproxy_global_nbproc is defined %}
     nbproc     {{ haproxy_global_nbproc }}
        {% if haproxy_global_cpu_maps %}
            {% for cpu_map in haproxy_global_cpu_maps %}


### PR DESCRIPTION
Disabled options haproxy_global_nbproc and haproxy_global_cpu_maps by default as they deprecated and will be removed in the HaProxy 2.5

Currently, if apply role on HAProxy version 2.3 occurred this warning:
```
    [WARNING] 362/134414 (345606) : nbproc is deprecated!
      | For suffering many limitations, the 'nbproc' directive is now deprecated
      | and scheduled for removal in 2.5. Just comment it out: haproxy will use
      | threads and will run on all allocated processors. You may also switch to
      | 'nbthread 2' to keep the same number of processors. If you absolutely
      | want to run in multi-process mode, you can silence this warning by adding
      | 'nbthread 1', but then please report your use case to developers.
```

This PR prevent warning.