### PR TITLE
Replace hard-coded service name with variable

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,6 +7,6 @@
 
 - name: Enabling and starting HAproxy service
   service:
-    name: haproxy
+    name: "{{ haproxy_service }}"
     state: started
     enabled: true


### PR DESCRIPTION
There is a variable already for the service name, but it is not used in the service task. Change the service task to use the `haproxy_service` variable so that the service name can be overridden.