### PR TITLE
Change docker task name for ansible <=2.9 compatibility

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: HAProxy - run a Docker container
-  community.general.docker_container:
+  docker_container:
     # common settings
     name: "{{ haproxy_docker_name }}"
     hostname: "{{ inventory_hostname }}"


### PR DESCRIPTION
By changing the docker_container task name to the <=2.9 style, backwards compatibility is preserved. Not sure from the recent commits if you are headed in a minimum support of 2.10+ or not.