### PR TITLE
support for TLS stats connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ haproxy_userlist:
 haproxy_stats: true
 haproxy_stats_address: '*'
 haproxy_stats_port: 9001
+haproxy_stats_ssl: false
 haproxy_stats_user: haproxy-stats
 haproxy_stats_password: B1Gp4sSw0rD!!
 haproxy_stats_uri: /

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,6 +79,7 @@ haproxy_default_errorfiles:
 haproxy_stats: true
 haproxy_stats_address: '*'
 haproxy_stats_port: 9001
+haproxy_stats_ssl: false
 haproxy_stats_auth: true
 haproxy_stats_user: haproxy-stats
 haproxy_stats_password: B1Gp4sSw0rD!!

--- a/templates/etc/haproxy/haproxy-stats.cfg.j2
+++ b/templates/etc/haproxy/haproxy-stats.cfg.j2
@@ -3,7 +3,11 @@
 #         STATS          #
 ##########################
 listen stats
+{% if haproxy_stats_ssl is defined and haproxy_stats_ssl|bool %}
+    bind       {{ haproxy_stats_address }}:{{ haproxy_stats_port }} {{ haproxy_ssl }}
+{% else %}
     bind       {{ haproxy_stats_address }}:{{ haproxy_stats_port }}
+{% endif %}
     mode       http
     maxconn    10
     stats      enable

--- a/tests/test-templates.yml
+++ b/tests/test-templates.yml
@@ -37,3 +37,39 @@
       assert:
         that:
           - listener is search('\n +rate-limit +sessions +2\n')
+
+
+- name: test stats connection clear text by default
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - ../defaults/main.yml
+  vars:
+    stats: "{{ lookup('template', '../templates/etc/haproxy/haproxy-stats.cfg.j2') }}"
+    statsBinds: "{{ stats | regex_findall('\n +bind [^\n]*') }}"
+  tasks:
+    - name: verify default stats bind statement
+      assert:
+        that:
+          - statsBinds | length == 1
+          - statsBinds[0] is not search('ssl crt')
+
+
+- name: test stats connection is encrypted when requested
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - ../defaults/main.yml
+    - vars/stats-ssl.yml
+  vars:
+    stats: "{{ lookup('template', '../templates/etc/haproxy/haproxy-stats.cfg.j2') }}"
+    statsBinds: "{{ stats | regex_findall('\n +bind [^\n]*')}}"
+    expectedBind: "{{ haproxy_stats_address }}:{{ haproxy_stats_port }} {{ haproxy_ssl }}"
+  tasks:
+    - name: verify encrypted stats bind statement
+      assert:
+        that:
+          - statsBinds | length == 1
+          - statsBinds[0] is search('bind +' + (expectedBind | regex_escape))

--- a/tests/vars/stats-ssl.yml
+++ b/tests/vars/stats-ssl.yml
@@ -1,0 +1,2 @@
+---
+haproxy_stats_ssl: true


### PR DESCRIPTION
The commit adds the ability to configure the HAProxy stats service to use TLS connections. When the new role variable `haproxy_stats_ssl` is set to `true` the `bind` configuration value in the `listen stats` definition will include the TLS configuration parameters provided by the variable `haproxy_ssl`. To preserve the current behavior of the role, the default value of `haproxy_stats_ssl` is `false`.