### PR TITLE
[selinux] install python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ haproxy_errors_directory: /usr/local/etc/haproxy/errors
 
 # Package customizations
 haproxy_package: haproxy
+haproxy_selinux_packages:
+  - python3-libselinux
+  - python3-policycoreutils
 haproxy_service: haproxy
 haproxy_bin: haproxy
 haproxy_config: /etc/haproxy/haproxy.cfg

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,9 @@ haproxy_errors_directory: /usr/local/etc/haproxy/errors
 
 # Package customizations
 haproxy_package: haproxy
+haproxy_selinux_packages:
+  - python3-libselinux
+  - python3-policycoreutils
 haproxy_service: haproxy
 haproxy_bin: haproxy
 haproxy_config: /etc/haproxy/haproxy.cfg

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -12,3 +12,9 @@
     update_cache: true
     cache_valid_time: 3600
     default_release: "{{ haproxy_release | default(ansible_distribution_release) }}"
+
+- name: "Installing selinux python bindings"
+  apt:
+    name: "{{ haproxy_selinux_packages }}"
+    state: present
+  when: haproxy_selinux | bool

--- a/tasks/install-Generic.yml
+++ b/tasks/install-Generic.yml
@@ -20,3 +20,9 @@
 - name: Installing HAproxy package
   package:
     name: "{{ haproxy_package }}"
+
+- name: "Installing selinux python bindings"
+  package:
+    name: "{{ haproxy_selinux_packages }}"
+    state: present
+  when: haproxy_selinux | bool

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,6 @@
 ---
 # file: roles/haproxy/vars/Debian.yml
+haproxy_selinux_packages:
+  - python3-selinux
+  - python3-sepolicy
 haproxy_errors_directory: /etc/haproxy/errors


### PR DESCRIPTION
This installs the required dependencies when haproxy_selinux is True.

When the dependencies were missing, errors like these were triggered:

```
TASK [uoi-io.haproxy : Allowing HAproxy to listen on some TCP ports] ********************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'selinux'
fatal: [test-haproxy-01]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (libselinux-python) on test-haproxy-01's Python /usr/bin/python3. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'typeattributes'

TASK [uoi-io.haproxy : Allowing HAproxy to listen on some TCP ports] *****************************************************************************************************************************************$An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'seobject'
fatal: [test-haproxy-01]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (policycoreutils-python) on test-haproxy-01's Python /usr/bin/python3. Please read the module docum$ntation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'seobject'
```
