### PR TITLE
Add a default value to haproxy_stats_listener_options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,7 +93,7 @@ haproxy_stats_options:
   - show-legends
   - show-node
   - hide-version
-# haproxy_stats_listener_options:
+haproxy_stats_listener_options: []
 
 # SSL
 haproxy_ssl_certificate: /etc/ssl/uoi.io/uoi.io.pem


### PR DESCRIPTION
Otherwise the playbook will return

```console
ansible.errors.AnsibleUndefinedVariable: 'haproxy_stats_listener_options'
is undefined
```

Closes: #47

Signed-off-by: Dimitri Savineau <savineau.dimitri@gmail.com>