### PR TITLE
improve idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ haproxy_selinux_packages:
 haproxy_service: haproxy
 haproxy_bin: haproxy
 haproxy_config: /etc/haproxy/haproxy.cfg
+haproxy_config_timestamp: false  # set to True to include a timestamp in the config file
 
 # Firewall
 haproxy_fw_ports:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ haproxy_selinux_packages:
 haproxy_service: haproxy
 haproxy_bin: haproxy
 haproxy_config: /etc/haproxy/haproxy.cfg
+haproxy_config_timestamp: false  # set to True to include a timestamp in the config file
 
 # Firewall
 haproxy_fw_ports:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -84,7 +84,7 @@ scenario:
     - create
     - prepare
     - converge
-    # - idempotence
+    - idempotence
     - side_effect
     - verify
     - cleanup

--- a/templates/etc/haproxy/haproxy.cfg.j2
+++ b/templates/etc/haproxy/haproxy.cfg.j2
@@ -1,7 +1,7 @@
 #jinja2: lstrip_blocks: True
 #
 # {{ ansible_managed }}
-# generated from the template on {{ ansible_date_time.iso8601 }}
+# generated from the template {% if haproxy_config_timestamp|bool -%} on {{ ansible_date_time.iso8601 }} {%- endif %}
 
 {# GLOBAL CONFIGURATION #}
 {% include 'haproxy-global.cfg.j2' %}


### PR DESCRIPTION
breaking: use `haproxy_config_timestamp` to include timestamp in config, defaults to false. 

Also enables idempotence molecule test.

`molecule test` completes successfully after rebasing from [my other PR ](https://github.com/uoi-io/ansible-haproxy/pull/54)