### PR TITLE
allow ACLs in stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,15 @@ haproxy_default_monitor_uri:
 
 # Userlist
 haproxy_userlist:
+  - stats-auth:
+      groups:
+        - "admin users admin"
+        - "readonly users user"
+      users:
+        - "admin insecure-password opqrstuvw"
+        - "user insecure-password abcdefghi"
 
-# Stats
+# Stats with HTTP Basic Auth and a single user
 haproxy_stats: true
 haproxy_stats_address: '*'
 haproxy_stats_port: 9001
@@ -144,6 +151,23 @@ haproxy_stats_timeouts:
   - server 100s
   - connect 100s
   - queue 100s
+
+# Stats with HTTP Basic Auth using an userlist
+haproxy_stats: true
+haproxy_stats_address: "::"
+haproxy_stats_port: 8081
+haproxy_stats_ssl: false
+haproxy_stats_uri: /stats
+haproxy_stats_auth:
+haproxy_stats_acls:
+  - "AUTH http_auth(stats-auth)"
+  - "AUTH_ADMIN http_auth_group(stats-auth) admin"
+haproxy_stats_options:
+  - refresh 5s
+  - show-legends
+  - show-node
+  - http-request auth unless AUTH
+  - admin if AUTH_ADMIN
 
 # SSL
 haproxy_ssl_certificate: /etc/ssl/uoi.io/uoi.io.pem

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,6 +89,7 @@ haproxy_stats_address: '*'
 haproxy_stats_port: 9001
 haproxy_stats_ssl: false
 haproxy_stats_auth: true
+haproxy_stats_acls: []
 haproxy_stats_user: haproxy-stats
 haproxy_stats_password: B1Gp4sSw0rD!!
 haproxy_stats_uri: /

--- a/templates/etc/haproxy/haproxy-stats.cfg.j2
+++ b/templates/etc/haproxy/haproxy-stats.cfg.j2
@@ -10,6 +10,11 @@ listen stats
 {% endif %}
     mode       http
     maxconn    10
+{% if haproxy_stats_acls is defined and haproxy_stats_acls|length %}
+    {% for acl in haproxy_stats_acls %}
+    acl        {{ acl }}
+    {% endfor %}
+{% endif %}
     stats      enable
 {% for opt in haproxy_stats_options %}
     stats      {{ opt }}


### PR DESCRIPTION
Hi,

this MR allows to use ACLs in stats. This is useful if you have a userlist with 'read-only' and 'admin' users.

Here's an example configuration (haproxy_stats_auth needs to be empty):
```
# Userlist
haproxy_userlist:
  - stats-auth:
      groups:
        - "admin users admin"
        - "readonly users user"
      users:
        - "admin insecure-password opqrstuvw"
        - "user insecure-password abcdefghi"

# Stats
haproxy_stats_address: "::"
haproxy_stats_port: 8081
haproxy_stats_ssl: true
haproxy_stats_uri: /stats
haproxy_stats_acls:
  - "AUTH http_auth(stats-auth)"
  - "AUTH_ADMIN http_auth_group(stats-auth) admin"
haproxy_stats_options:
  - refresh 5s
  - show-legends
  - show-node
  - http-request auth unless AUTH
  - admin if AUTH_ADMIN
haproxy_stats_auth:
```