### PR TITLE
added missing endif

### DIFF
--- a/templates/etc/haproxy/haproxy-backend.cfg.j2
+++ b/templates/etc/haproxy/haproxy-backend.cfg.j2
@@ -24,6 +24,7 @@ backend {{ name }}
                 {% for http_check in value.http_checks %}
     http-check      {{ http_check }}
                 {% endfor %}
+            {% endif %}
             {% if value.cookie is defined %}
     cookie          {{ value.cookie }}
             {% endif %}


### PR DESCRIPTION
hey,
sorry, there was and 'endif' missing in the template.