### PR TITLE
default-server option is also valid in 'listen'

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ haproxy_listen:
       mode: http
       description: Horizon Dashboard
       balance: roundrobin
+      default_server: "inter 2s downinter 5s rise 3 fall 2 slowstart 30s maxconn 30 maxqueue 64 weight 100"
       binds:
         - 10.0.0.100:80
       binds_ssl:

--- a/templates/etc/haproxy/haproxy-listen.cfg.j2
+++ b/templates/etc/haproxy/haproxy-listen.cfg.j2
@@ -8,6 +8,9 @@ listen {{ name }}
             {% if value.mode is defined %}
     mode            {{ value.mode }}
             {% endif %}
+            {% if value.default_server is defined %}
+    default-server  {{ value.default_server }}
+            {% endif %}
             {% if value.description is defined %}
     description     {{ value.description }}
             {% endif %}


### PR DESCRIPTION
the 'default-server' directive can now also be used in the 'listen' part