### PR TITLE
Adding prometheus metrics in stats 

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ haproxy_stats_options:
   - show-legends
   - show-node
   - hide-version
+haproxy_stats_http_requests:
+  - use-service prometheus-exporter if { path /metrics }
 haproxy_stats_listener_options:
   - dontlog-normal
 haproxy_stats_timeouts:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,6 +99,7 @@ haproxy_stats_options:
   - show-node
   - hide-version
 haproxy_stats_listener_options: []
+haproxy_stats_http_requests: []
 haproxy_stats_timeouts:
   - client 100s
   - server 100s

--- a/templates/etc/haproxy/haproxy-stats.cfg.j2
+++ b/templates/etc/haproxy/haproxy-stats.cfg.j2
@@ -27,6 +27,9 @@ listen stats
 {% for listener_opt in haproxy_stats_listener_options %}
     option     {{ listener_opt }}
 {% endfor %}
+{% for http_request in haproxy_stats_http_requests %}
+    http-request     {{ http_request }}
+{% endfor %}
 {% if haproxy_stats_timeouts is defined and haproxy_stats_timeouts|length %}
     {% for timeout in haproxy_stats_timeouts %}
     timeout    {{ timeout }}


### PR DESCRIPTION
Hello,

We are adding one var in stats template to get the possibility to scrape native haproxy prometheus values.

At the moment this line :

http-request use-service prometheus-exporter if { path /metrics }

cannot be added, so we fix this.