### PR TITLE
Dev #86: ignores startup errors in case we're reconfiguring

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,10 +6,3 @@
 - name: Include Generic tasks
   include_tasks: install-Generic.yml
   when: ansible_os_family != 'Debian'
-
-- name: Enabling and starting HAproxy service
-  ansible.builtin.service:
-    name: "{{ haproxy_service }}"
-    state: started
-    enabled: true
-  ignore_errors: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,3 +12,4 @@
     name: "{{ haproxy_service }}"
     state: started
     enabled: true
+  ignore_errors: true


### PR DESCRIPTION
This corrects the blocking of reconfiguration when the service can't start. 

The notify for configuration will cause a reload on service configuration, so ignoring it causes no harm, but failure is not tolerated completed as the handler will fail instead. 

Now to fix my config :) 

```
TASK [uoi-io.haproxy : Installing HAproxy package] *****************************
ok: [dev-vps] => {"changed": false, "msg": "Nothing to do", "rc": 0, "results": []}

...

TASK [uoi-io.haproxy : Enabling and starting HAproxy service] ******************
fatal: [dev-vps]: FAILED! => {"changed": false, "msg": "Unable to start service haproxy: Job for haproxy.service failed because the control process exited with error code.\nSee \"systemctl status haproxy.service\" and \"journalctl -xeu haproxy.service\" for details.\n"}
...ignoring

...

TASK [uoi-io.haproxy : Configuring HAproxy] ************************************
changed: [dev-vps] => {"changed": true, "checksum": "3adb2817b21bd46bfd2621355e72ac54d06f6297", "dest": "/etc/haproxy/haproxy.cfg", "gid": 0, "group": "root", "md5sum": "190cab6249bab64322e9dfc0d17c3035", "mode": "0640", "owner": "root", "secontext": "system_u:object_r:etc_t:s0", "size": 2510, "src": "/home/circadian/.ansible/tmp/ansible-tmp-1746974539.8727362-380527-237143157111808/source", "state": "file", "uid": 0}

...

(Another start task fails here, but notice the handlers due to restart below...)

RUNNING HANDLER [uoi-io.haproxy : Restart haproxy] *****************************

RUNNING HANDLER [uoi-io.haproxy : Reload haproxy] ******************************

PLAY RECAP *********************************************************************
dev-vps                    : ok=111  changed=5    unreachable=0    failed=1    skipped=50   rescued=0    ignored=1   
```